### PR TITLE
Fix: mac prefixed with leading zeros

### DIFF
--- a/src-tauri/src/db_service/db_service.rs
+++ b/src-tauri/src/db_service/db_service.rs
@@ -186,13 +186,13 @@ pub fn add_to_device_table(
     country: &str,
     router_mac: &str,
 ) -> Result<()> {
-    if mac_address == router_mac {
+    let cleaned_mac = clean_mac_address(mac_address);
+    let cleaned_router = clean_mac_address(router_mac);
+
+    if cleaned_mac == cleaned_router {
         println!("Skipped adding device as it matches router MAC");
         return Ok(());
     }
-
-    let cleaned_mac = clean_mac_address(mac_address);
-    let cleaned_router = clean_mac_address(router_mac);
 
     let exists: bool = conn.query_row(
         "SELECT EXISTS(SELECT 1 FROM devices WHERE mac_address = ?1 AND router_mac = ?2)",


### PR DESCRIPTION
As the OUI table, used to get manufacturer info, includes leading zeros, we figured we might want to standardize the mac address representation in DD to fit that. This PR moves mac address representation to that format.

I do however not like the way we do this, having to call the clean_mac_address function everytime... 

@halli21  can you find a better way? I know @lsig can't 😂