### PR TITLE
Feat/styling

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -60,7 +60,9 @@
         "height": 600,
         "resizable": true,
         "title": "The Desktop Defender",
-        "width": 800
+        "width": 870,
+        "minHeight": 400,
+        "minWidth": 870
       }
     ]
   }

--- a/src/app/monitor/page.tsx
+++ b/src/app/monitor/page.tsx
@@ -4,22 +4,21 @@ import { RealTimeChart } from "@/components/Chart";
 import { IpTable } from "@/components/InfoTable";
 import { PacketTable } from "@/components/PacketTable";
 import { CountryPieChart } from "@/components/PieChart";
+import DDPageContainer from "@/components/DDPageContainer";
 
 export default function Monitor() {
   return (
-    <div className="flex flex-col px-8">
-      <div>
+    <DDPageContainer>
+      <>
         <RealTimeChart />
         <IpTable />
-      </div>
-      <div className="flex flex-row justify-between items-start">
-        <div className="pt-16">
-          <CountryPieChart />
-        </div>
-        <div>
+        <div className="flex justify-center items-center">
+          <div className="pt-8">
+            <CountryPieChart />
+          </div>
           <PacketTable />
         </div>
-      </div>
-    </div>
+      </>
+    </DDPageContainer>
   );
 }

--- a/src/components/DDPageContainer.tsx
+++ b/src/components/DDPageContainer.tsx
@@ -4,7 +4,7 @@ interface Props {
 
 export default function DDPageContainer({ children }: Props) {
   return (
-    <main className="border-x-2 border-dashed flex justify-center h-screen">
+    <main className="border-x-2 border-dashed flex flex-col justify-center py-4">
       {children}
     </main>
   );

--- a/src/components/PacketTable.tsx
+++ b/src/components/PacketTable.tsx
@@ -30,7 +30,7 @@ export function PacketTable() {
   }, []);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-between p-4">
+    <div className="flex flex-col items-center justify-between p-4">
       <div className="overflow-x-auto">
         <table className="table">
           <thead>


### PR DESCRIPTION
In this PR the monitor page was restyled, a minimum width was set and the default for DDContainer was set to flex-col instead of flex-row. Additionally minimum height was removed.